### PR TITLE
Fix the build with the recent aeson release

### DIFF
--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -100,7 +100,7 @@ import Data.String (fromString)
 import Data.Maybe (fromMaybe)
 import qualified Data.Char as C
 
-import Prelude hiding (catch)
+import Prelude
 
 
 -- |Convenience function to handle webdriver commands with no return value
@@ -787,4 +787,4 @@ getApplicationCacheStatus = doSessCommand GET "/application_cache/status" Null
 
 -- Moving this closer to the definition of Cookie seems to cause strange compile
 -- errors, so I'm leaving it here for now.
-$( deriveToJSON (map C.toLower . drop 4) ''Cookie )
+$( deriveToJSON (defaultOptions{fieldLabelModifier = map C.toLower . drop 4}) ''Cookie )

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -30,7 +30,7 @@ library
   hs-source-dirs: src
   ghc-options: -Wall
   build-depends:   base == 4.*
-                 , aeson >= 0.4 && < 0.7
+                 , aeson >= 0.6.2.0 && < 0.7
                  , HTTP >= 4000.1 && < 4000.3
                  , mtl >= 2.0 && < 2.2
                  , network == 2.4.*


### PR DESCRIPTION
The template haskell derivation API has changed in `aeson-0.6.2.0`, released yesterday. This breaks the build for `webdriver`. I'm submitting a patch that fixes the build with that version. I've tested it with Firefox and the test succeeded (with selenium-server-2.33.0), but I'm unable to test it with Chrome. Also, note that the test still fails on the newer selenium-server-2.35.0.
