### PR TITLE
Make asyncJS distinguish between timeout and null return

### DIFF
--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -217,7 +217,7 @@ returned as the result of asyncJS. A result of Nothing indicates that the
 Javascript function timed out (see 'setScriptTimeout')
 -}
 asyncJS :: (WebDriver wd, FromJSON a) => [JSArg] -> Text -> wd (Maybe a)
-asyncJS a s = handle timeout $ fromJSON' =<< getResult
+asyncJS a s = handle timeout $ Just <$> (fromJSON' =<< getResult)
   where
     getResult = doSessCommand POST "/execute_async" . pair ("args", "script")
                 $ (a,s)

--- a/test/async.hs
+++ b/test/async.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Async where
+
+import Test.WebDriver
+import qualified Data.Aeson as A
+
+main :: IO ()
+main = runSession defaultSession defaultCaps $ do
+    openPage "http://www.wikipedia.org/"
+    r <- asyncJS [] "arguments[0]();"
+    if r /= Just A.Null
+      then error $ "Async returned " ++ show r
+      else return ()


### PR DESCRIPTION
When the javascript function passed to asyncJS calls the callback
with no parameters, webdriver interprets this as a JSON Null return
value.  The asyncJS function would then parse this to Nothing, so that
it is impossible to know if the asyncJS function timed out or completed
successfully since a timeout is also signaled by Nothing.  Therefore,
when asyncJS completes successfully, force a Just.  This causes the Null
to become (Just Null) which can be distinguished from timeout.
