### PR TITLE
Support aeson 0.7

### DIFF
--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -89,6 +89,7 @@ import Data.ByteString.Base64.Lazy as B64
 import Data.ByteString.Lazy as LBS (ByteString)
 import Network.URI hiding (path)  -- suppresses warnings
 import Codec.Archive.Zip
+import qualified Data.Text.Lazy.Encoding as TL
 
 import Control.Applicative
 import Control.Monad.State.Strict
@@ -231,7 +232,7 @@ screenshot = B64.decodeLenient <$> screenshotBase64
 
 -- |Grab a screenshot as a base-64 encoded PNG image. This is the protocol-defined format.
 screenshotBase64 :: WebDriver wd => wd LBS.ByteString
-screenshotBase64 = doSessCommand GET "/screenshot" Null
+screenshotBase64 = TL.encodeUtf8 <$> doSessCommand GET "/screenshot" Null
 
 availableIMEEngines :: WebDriver wd => wd [Text]
 availableIMEEngines = doSessCommand GET "/ime/available_engines" Null
@@ -695,7 +696,7 @@ uploadRawFile path t str = uploadZipEntry (toEntry path t str)
 -- the zip entry sent across network.
 uploadZipEntry :: WebDriver wd => Entry -> wd ()
 uploadZipEntry = noReturn . doSessCommand POST "/file" . single "file"
-                 . B64.encode . fromArchive . (`addEntryToArchive` emptyArchive)
+                 . TL.decodeUtf8 . B64.encode . fromArchive . (`addEntryToArchive` emptyArchive)
 
 
 -- |Get the current number of keys in a web storage area.

--- a/src/Test/WebDriver/Internal.hs
+++ b/src/Test/WebDriver/Internal.hs
@@ -24,6 +24,7 @@ import Data.Text as T (Text, unpack, splitOn, null)
 import Data.ByteString.Lazy.Char8 (ByteString)
 import Data.ByteString.Lazy.Char8 as LBS (length, unpack, null)
 import qualified Data.ByteString.Base64.Lazy as B64
+import qualified Data.Text.Lazy.Encoding as TL
 
 import Control.Monad.Base
 import Control.Exception.Lifted (throwIO)
@@ -322,7 +323,7 @@ instance FromJSON FailedCommandInfo where
   parseJSON (Object o) =
     FailedCommandInfo <$> (req "message" >>= maybe (return "") return)
                       <*> pure undefined
-                      <*> opt "screen"     Nothing
+                      <*> (fmap TL.encodeUtf8 <$> opt "screen" Nothing)
                       <*> opt "class"      Nothing
                       <*> opt "stackTrace" []
     where req :: FromJSON a => Text -> Parser a

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -53,6 +53,7 @@ library
                  , temporary >= 1.0 && < 2.0
                  , base64-bytestring >= 1.0 && < 1.1
                  , cond >= 0.3 && < 0.5
+                 , scientific >= 0.2 && < 0.3
 
   exposed-modules: Test.WebDriver
                    Test.WebDriver.Classes


### PR DESCRIPTION
Webdriver 0.5.3.1 doesn't compile with aeson 0.7.  You added a message to the changelog that it works but didn't fix all the compile errors.  Here is a conversion, although I don't know if you want to require aeson 0.7 and then change ProfilePref to just store the original ScientificNumber
