### PR TITLE
Relaxed text version up to 1.2.0.0

### DIFF
--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -35,7 +35,7 @@ library
                  , mtl >= 2.0 && < 2.2
                  , network == 2.4.*
                  , bytestring >= 0.9 && < 0.11
-                 , text >= 0.11.3 && < 0.12
+                 , text >= 0.11.3 && < 1.2.0.0
                  , time == 1.*
                  , transformers >= 0.2 && < 0.5
                  , zip-archive >= 0.1.1.8 && < 0.3


### PR DESCRIPTION
Text dependency < 0.12 conflicts with up to date packages (which depends on text > 1.0).
