### PR TITLE
Baidu now has two elements with name wd

### DIFF
--- a/test/search-baidu.hs
+++ b/test/search-baidu.hs
@@ -20,7 +20,7 @@ baidu = openPage "http://www.baidu.com/"
 
 searchBaidu :: WD Bool
 searchBaidu = do
-  searchBox <- findElem (ByName "wd")
+  searchBox <- findElem (ById "kw1")
   sendKeys "Cheese!" searchBox
   submit searchBox
   setImplicitWait 50


### PR DESCRIPTION
But id "kw1" is unique, and thus the example runs after this modification.
