### PR TITLE
Replaced MonadCatchIO with exceptions and relaxed some dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 #Change Log
+##0.5.4
+* MonadCatchIO is deprecated in favour of exceptions
+* Relaxed dependencies on mtl, network and scientific
+
 ##0.5.3.3
 * Relaxed text dependency up to 1.2
 

--- a/src/Test/WebDriver/Monad.hs
+++ b/src/Test/WebDriver/Monad.hs
@@ -16,14 +16,14 @@ import Control.Monad.Trans.Control (MonadBaseControl(..), StM)
 import Control.Monad.State.Strict (StateT, MonadState, evalStateT, get, put)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Exception.Lifted
-import Control.Monad.CatchIO (MonadCatchIO)
+import Control.Monad.Catch (MonadThrow, MonadCatch)
 import Control.Applicative
 
 {- |A monadic interface to the WebDriver server. This monad is simply a
     state monad transformer over 'IO', threading session information between sequential webdriver commands
 -}
 newtype WD a = WD (StateT WDSession IO a)
-  deriving (Functor, Applicative, Monad, MonadIO, MonadCatchIO)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadCatch)
 
 instance MonadBase IO WD where
   liftBase = WD . liftBase

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -1,5 +1,5 @@
 Name: webdriver
-Version: 0.5.3.3
+Version: 0.5.4
 Cabal-Version: >= 1.8
 License: BSD3
 License-File: LICENSE
@@ -32,8 +32,8 @@ library
   build-depends:   base == 4.*
                  , aeson >= 0.6.2.0 && < 0.8
                  , HTTP >= 4000.1 && < 4000.3
-                 , mtl >= 2.0 && < 2.2
-                 , network == 2.4.*
+                 , mtl >= 2.0 && < 2.3
+                 , network >= 2.4 && < 2.6
                  , bytestring >= 0.9 && < 0.11
                  , text >= 0.11.3 && < 1.2.0.0
                  , time == 1.*
@@ -47,13 +47,13 @@ library
                  , transformers-base >= 0.1 && < 1.0
                  , vector >= 0.3 && < 0.11
                  , lifted-base >= 0.1 && < 0.3
-                 , MonadCatchIO-transformers >= 0.3 && < 0.4
+                 , exceptions >= 0.4 && < 0.6
                  , directory-tree == 0.11.*
                  , data-default >= 0.2 && < 1.0
                  , temporary >= 1.0 && < 2.0
                  , base64-bytestring >= 1.0 && < 1.1
                  , cond >= 0.3 && < 0.5
-                 , scientific >= 0.2 && < 0.3
+                 , scientific >= 0.2 && < 0.4
 
   exposed-modules: Test.WebDriver
                    Test.WebDriver.Classes


### PR DESCRIPTION
Hi,

So, currently MonadCatchIO-transfomers is [marked deprecated](http://hackage.haskell.org/package/MonadCatchIO-transformers), recommending the use of [exceptions](https://hackage.haskell.org/package/exceptions) instead. I've made (what I believe are) the necessary changes.

I've also relaxed some depencies to match the latest version of some packages... I've gone through their changelog and nothing relevant seems to have changed.

Please let me know if you are ok with these changes (and the proposed new version).

Cheers
