### PR TITLE
Handle JSON error in the body even if status code is 2xx

### DIFF
--- a/src/Test/WebDriver/Internal.hs
+++ b/src/Test/WebDriver/Internal.hs
@@ -97,7 +97,7 @@ handleHTTPErr r@Response{rspBody = body, rspCode = code, rspReason = reason} =
         Nothing ->
           err (ServerError . ("Missing content type. Server response: "++))
 
-    (2,_,_)  -> return ()
+    (2,_,_)  -> parseJSON' body >>= handleJSONErr
     (3,0,x) | x `elem` [2,3]
              -> return ()
     _        -> err (HTTPStatusUnknown code)
@@ -146,6 +146,7 @@ handleJSONErr WDResponse{rspVal = val, rspStatus = status} = do
                          , errScreen = screen }
       e errType = throwIO $ FailedCommand errType errInfo'
   case status of
+    0   -> return ()
     7   -> e NoSuchElement
     8   -> e NoSuchFrame
     9   -> throwIO . UnknownCommand . errMsg $ errInfo


### PR DESCRIPTION
I'm not sure about other drivers, but chromedriver surely reports 200 when the command fails. That's why modified `handleHTTPErr` to handle the error info in the body as well. Not sure if it fits the big picture, but it's the easy way.
