### PR TITLE
By default, http-conduit throws expcetion on all non-200 status

### DIFF
--- a/src/Test/WebDriver/Internal.hs
+++ b/src/Test/WebDriver/Internal.hs
@@ -61,6 +61,7 @@ mkRequest headers meth wdPath args = do
              , requestHeaders = headers ++ [ (hAccept, "application/json;charset=UTF-8")
                                            , (hContentType, "application/json;charset=UTF-8")
                                            , (hContentLength, fromString . show . LBS.length $ body) ]
+             , checkStatus = \_ _ _ -> Nothing -- all status codes handled by getJSONResult
              , method = meth }
 
 -- |Sends an HTTP request to the remote WebDriver server


### PR DESCRIPTION
See http://hackage.haskell.org/package/http-conduit-2.1.4/docs/Network-HTTP-Conduit.html#v:checkStatus

Also, running hlint gave me this error:

```
src/Test/WebDriver/Internal.hs|149 col 19 warning| Warning: Literal 405 is out of the Word8 range 0..255
```

It seems like an actual error, the type of status in WDResponse should be changed to Int.
