### PR TITLE
Avoid crash when prefs.js does not exist

### DIFF
--- a/src/Test/WebDriver/Firefox/Profile.hs
+++ b/src/Test/WebDriver/Firefox/Profile.hs
@@ -139,7 +139,11 @@ loadProfile path = liftBase $ do
                          ,"parent.lock", ".parentlock", ".lock"
                          ,userPrefFile])
 
-    getPrefs = HM.fromList <$> (parsePrefs =<< BS.readFile userPrefFile)
+    getPrefs = do
+       prefFileExists <- doesFileExist userPrefFile
+       if prefFileExists
+        then HM.fromList <$> (parsePrefs =<< BS.readFile userPrefFile)
+        else return HM.empty
       where parsePrefs s = either (throwIO . ProfileParseError) return
                            $ parseOnly prefsParser s
 


### PR DESCRIPTION
Firefox profiles could not have the prefs.js file and still work. This patch fallback to empty preferences when the file does not exist.
