### PR TITLE
Relaxed version bounds for GHC 7.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 #Change Log
+
+##0.6.0.2
+* Relaxed version bounds for GHC 7.8.3
+
 ##0.6
 * Rather than WDSession serving dual roles as configuration and state, its functionality has been split into 2 respective types: WDConfig and WDSession.
 * runSession now takes a WDConfig instead of WDSession and Capabilities parameters.

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -1,5 +1,5 @@
 Name: webdriver
-Version: 0.6.0.1
+Version: 0.6.0.2
 Cabal-Version: >= 1.8
 License: BSD3
 License-File: LICENSE
@@ -31,10 +31,11 @@ library
   ghc-options: -Wall
   build-depends:   base == 4.*
                  , aeson >= 0.6.2.0 && < 0.9
-                 , network >= 2.4 && < 2.6
-                 , http-client >= 0.3 && < 0.4
+                 , network >= 2.4 && < 2.7
+                 , network-uri
+                 , http-client >= 0.3 && < 0.5
                  , http-types >= 0.8 && < 0.9
-                 , text >= 0.11.3 && < 1.2.0.0
+                 , text >= 0.11.3 && < 1.3.0.0
                  , bytestring >= 0.9 && < 0.11
                  , attoparsec < 0.13
                  , base64-bytestring >= 1.0 && < 1.1


### PR DESCRIPTION
Untested on earlier versions of GHC and library setups.
