### PR TITLE
(#60) Quick Fix: simplified some code.

### DIFF
--- a/src/Test/WebDriver/Internal.hs
+++ b/src/Test/WebDriver/Internal.hs
@@ -29,7 +29,7 @@ import Data.Text as T (Text, splitOn, null)
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy.Encoding as TLE
 import Data.ByteString.Lazy.Char8 (ByteString)
-import Data.ByteString.Lazy.Char8 as LBS (length, unpack, null, fromChunks)
+import Data.ByteString.Lazy.Char8 as LBS (length, unpack, null, fromStrict)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Base64.Lazy as B64
 
@@ -86,7 +86,7 @@ getJSONResult r
       Just ct
         | "application/json" `BS.isInfixOf` ct ->
           parseJSON' 
-            (maybe body (LBS.fromChunks . (:[])) (lookup "X-Response-Body-Start" headers))
+            (maybe body LBS.fromStrict $ lookup "X-Response-Body-Start" headers)
           >>= handleJSONErr
           >>= maybe noReturn returnErr
         | otherwise -> 


### PR DESCRIPTION
Here is my logic for the refactor:

```
$ :t (:[])
(:[]) :: a -> [a]
$ :t return
return :: Monad m => a -> m a
$ :t return :: (a -> [a])
return :: (a -> [a]) :: a -> [a]
$ :m + Data.ByteString.Lazy.Char8 
$ :t from
fromChunks    fromEnum      fromInteger   fromIntegral  fromRational  fromStrict
$ :t fromChunks . (:[])
fromChunks . (:[])
  :: Data.ByteString.Internal.ByteString -> ByteString
$ :t fromChunks . return
fromChunks . return
  :: Data.ByteString.Internal.ByteString -> ByteString
$ :t fromStrict 
fromStrict :: Data.ByteString.Internal.ByteString -> ByteString
$ 
```

As you can see (:[]) is just the list specific equivalent of the return function for monads. So you could write that line as fromChunks . return. 

However, there is no need as fromStrict does exactly what you need and I believe that it has been part of the Data.ByteString package for quite some time. Cheers!
