### PR TITLE
RFC: Catch and retry more exceptions (in waitUntil and friends).

### DIFF
--- a/src/Test/WebDriver/Commands/Wait.hs
+++ b/src/Test/WebDriver/Commands/Wait.hs
@@ -112,13 +112,15 @@ waitEither failure success = wait' handler
   handler retry wd = do
     e <- fmap Right wd  `catches` [Handler handleFailedCommand
                                   ,Handler handleExpectFailed
+                                  ,Handler handleSomeException
                                   ]
     either (failure retry) (success retry) e
    where
-    handleFailedCommand e@(FailedCommand NoSuchElement _) = return . Left . show $ e
-    handleFailedCommand err = throwIO err
+    handleFailedCommand e@(FailedCommand _ _) = return . Left . show $ e
 
     handleExpectFailed (e :: ExpectFailed) = return . Left . show $ e
+
+    handleSomeException (e :: SomeException) = return . Left . show $ e
 
 wait' :: (WDSessionStateIO m) =>
          ((String -> m b) -> m a -> m b) -> Int -> Double -> m a -> m b


### PR DESCRIPTION
Hi there, this is a basis for discussion, please do not merge it as is.

My situation: I am testing a react app, where DOM elements can go stale at surprising points in the code.  I can run `exceptNotStale` and `click` immediately after, and get a `FailedCommand StaleElementReference` from the latter.

In order to fix this, I propose to make `wait*` either capture more exception types, or make the catchable exception types customizable on the surface of this library.  In the latter case, I would need variants of all 5 `wait*` functions that take a list of exceptions to handle.  I guess passing in the exception `Handler`s would be even more flexible.

If you like, I would start module `WebDriver.Commands.Wait.Internal` where I provide these, but I am in favor of keeping everything in `Wait`.

Also if you want to accept any of this, I would update the documentation.

What do you think?

thanks!
