### PR TITLE
Update to Aeson 2

### DIFF
--- a/src/Test/WebDriver/Capabilities.hs
+++ b/src/Test/WebDriver/Capabilities.hs
@@ -8,7 +8,7 @@ import Test.WebDriver.JSON
 
 import Data.Aeson
 import Data.Aeson.Types (Parser, typeMismatch, Pair)
-import qualified Data.Aeson.KeyMap as HM (delete, empty, toList)
+import qualified Data.Aeson.KeyMap as KM (delete, empty, toList)
 
 import Data.Text (Text, toLower, toUpper)
 import Data.Default.Class (Default(..))
@@ -202,7 +202,7 @@ instance ToJSON Capabilities where
                   ] ++
                   [ "args"       .= chromeOptions
                   , "extensions" .= chromeExtensions
-                  ] ++ HM.toList chromeExperimentalOptions
+                  ] ++ KM.toList chromeExperimentalOptions
                 )]
         IE {..}
           -> ["ignoreProtectedModeSettings" .= ieIgnoreProtectedModeSettings
@@ -283,7 +283,7 @@ instance FromJSON Capabilities where
           b k = opt k Nothing     -- Maybe Bool field
 
           -- produce additionalCaps by removing known capabilities from the JSON object
-          additionalCapabilities = HM.toList . foldr HM.delete o . knownCapabilities
+          additionalCapabilities = KM.toList . foldr KM.delete o . knownCapabilities
 
           knownCapabilities browser =
             [ "browserName", "version", "platform", "proxy"
@@ -311,7 +311,7 @@ instance FromJSON Capabilities where
                                   <*> opt "chrome.binary" Nothing
                                   <*> opt "chrome.switches" []
                                   <*> opt "chrome.extensions" []
-                                  <*> pure HM.empty
+                                  <*> pure KM.empty
               IE {} -> IE <$> opt "ignoreProtectedModeSettings" True
                           <*> opt "ignoreZoomSettings" False
                           <*> opt "initialBrowserUrl" Nothing
@@ -538,7 +538,7 @@ firefox = Firefox Nothing def Nothing Nothing
 -- |Default Chrome settings. All Maybe fields are set to Nothing, no options are
 -- specified, and no extensions are used.
 chrome :: Browser
-chrome = Chrome Nothing Nothing [] [] HM.empty
+chrome = Chrome Nothing Nothing [] [] KM.empty
 
 -- |Default IE settings. See the 'IE' constructor for more details on
 -- individual defaults

--- a/src/Test/WebDriver/Capabilities.hs
+++ b/src/Test/WebDriver/Capabilities.hs
@@ -8,7 +8,7 @@ import Test.WebDriver.JSON
 
 import Data.Aeson
 import Data.Aeson.Types (Parser, typeMismatch, Pair)
-import qualified Data.HashMap.Strict as HM (delete, toList, empty)
+import qualified Data.Aeson.KeyMap as HM (delete, empty, toList)
 
 import Data.Text (Text, toLower, toUpper)
 import Data.Default.Class (Default(..))
@@ -47,7 +47,7 @@ useBrowser b = modifyCaps $ \c -> c { browser = b }
 useVersion :: HasCapabilities t => String -> t -> t
 useVersion v = modifyCaps $ \c -> c { version = Just v }
 
--- |A helper function for setting the 'platform' capability of a 'HasCapabilities' instance 
+-- |A helper function for setting the 'platform' capability of a 'HasCapabilities' instance
 usePlatform :: HasCapabilities t => Platform -> t -> t
 usePlatform p = modifyCaps $ \c -> c { platform = p }
 
@@ -242,7 +242,7 @@ instance ToJSON Capabilities where
 
         Phantomjs {..}
           -> catMaybes [ opt "phantomjs.binary.path" phantomjsBinary
-                       ] ++ 
+                       ] ++
                        [ "phantomjs.cli.args" .= phantomjsOptions
                        ]
 
@@ -275,11 +275,11 @@ instance FromJSON Capabilities where
                  <*> pure (additionalCapabilities browser)
 
     where --some helpful JSON accessor shorthands
-          req :: FromJSON a => Text -> Parser a
+          req :: FromJSON a => Key -> Parser a
           req = (o .:)            -- required field
-          opt :: FromJSON a => Text -> a -> Parser a
+          opt :: FromJSON a => Key -> a -> Parser a
           opt k d = o .:?? k .!= d -- optional field
-          b :: Text -> Parser (Maybe Bool)
+          b :: Key -> Parser (Maybe Bool)
           b k = opt k Nothing     -- Maybe Bool field
 
           -- produce additionalCaps by removing known capabilities from the JSON object
@@ -643,7 +643,7 @@ instance FromJSON ProxyType where
                          <*> f "httpProxy"
       _ -> fail $ "Invalid ProxyType " ++ show pTyp
     where
-      f :: FromJSON a => Text -> Parser a
+      f :: FromJSON a => Key -> Parser a
       f = (obj .:)
   parseJSON v = typeMismatch "ProxyType" v
 

--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -373,9 +373,9 @@ instance FromJSON Cookie where
                                 <*> opt "secure" Nothing
                                 <*> opt "expiry" Nothing
     where
-      req :: FromJSON a => Text -> Parser a
+      req :: FromJSON a => Key -> Parser a
       req = (o .:)
-      opt :: FromJSON a => Text -> a -> Parser a
+      opt :: FromJSON a => Key -> a -> Parser a
       opt k d = o .:?? k .!= d
   parseJSON v = typeMismatch "Cookie" v
 

--- a/src/Test/WebDriver/Exceptions/Internal.hs
+++ b/src/Test/WebDriver/Exceptions/Internal.hs
@@ -15,7 +15,6 @@ import Data.Aeson.Types (Parser, typeMismatch)
 import Data.ByteString.Lazy.Char8 (ByteString)
 import Data.CallStack
 import qualified Data.List as L
-import Data.Text (Text)
 import qualified Data.Text.Lazy.Encoding as TLE
 
 import Control.Applicative
@@ -174,9 +173,9 @@ instance FromJSON FailedCommandInfo where
                       <*> (fmap TLE.encodeUtf8 <$> opt "screen" Nothing)
                       <*> opt "class"      Nothing
                       <*> (catMaybes <$> opt "stackTrace" [])
-    where req :: FromJSON a => Text -> Parser a
+    where req :: FromJSON a => Key -> Parser a
           req = (o .:)            --required key
-          opt :: FromJSON a => Text -> a -> Parser a
+          opt :: FromJSON a => Key -> a -> Parser a
           opt k d = o .:?? k .!= d --optional key
   parseJSON v = typeMismatch "FailedCommandInfo" v
 
@@ -185,9 +184,9 @@ instance FromJSON StackFrame where
                                     <*> reqStr "className"
                                     <*> reqStr "methodName"
                                     <*> req    "lineNumber"
-    where req :: FromJSON a => Text -> Parser a
+    where req :: FromJSON a => Key -> Parser a
           req = (o .:) -- all keys are required
-          reqStr :: Text -> Parser String
+          reqStr :: Key -> Parser String
           reqStr k = req k >>= maybe (return "") return
   parseJSON v = typeMismatch "StackFrame" v
 

--- a/src/Test/WebDriver/JSON.hs
+++ b/src/Test/WebDriver/JSON.hs
@@ -36,7 +36,7 @@ import Data.Aeson.Types
 import Data.ByteString.Lazy.Char8 (ByteString)
 import Data.Attoparsec.ByteString.Lazy (Result(..))
 import qualified Data.Attoparsec.ByteString.Lazy as AP
-import qualified Data.Aeson.KeyMap as HM
+import qualified Data.Aeson.KeyMap as KM
 
 import Control.Monad (join, void)
 import Control.Applicative
@@ -60,7 +60,7 @@ data NoReturn = NoReturn
 
 instance FromJSON NoReturn where
   parseJSON Null                    = return NoReturn
-  parseJSON (Object o) | HM.null o  = return NoReturn
+  parseJSON (Object o) | KM.null o  = return NoReturn
   parseJSON (String "")             = return NoReturn
   parseJSON other                   = typeMismatch "no return value" other
 

--- a/src/Test/WebDriver/JSON.hs
+++ b/src/Test/WebDriver/JSON.hs
@@ -33,11 +33,10 @@ import Test.WebDriver.Class (WebDriver)
 
 import Data.Aeson as Aeson
 import Data.Aeson.Types
-import Data.Text (Text)
 import Data.ByteString.Lazy.Char8 (ByteString)
 import Data.Attoparsec.ByteString.Lazy (Result(..))
 import qualified Data.Attoparsec.ByteString.Lazy as AP
-import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson.KeyMap as HM
 
 import Control.Monad (join, void)
 import Control.Applicative
@@ -75,18 +74,18 @@ ignoreReturn = void
 
 
 -- |Construct a singleton JSON 'object' from a key and value.
-single :: ToJSON a => Text -> a -> Value
+single :: ToJSON a => Key -> a -> Value
 single a x = object [a .= x]
 
 -- |Construct a 2-element JSON 'object' from a pair of keys and a pair of
 -- values.
-pair :: (ToJSON a, ToJSON b) => (Text,Text) -> (a,b) -> Value
+pair :: (ToJSON a, ToJSON b) => (Key,Key) -> (a,b) -> Value
 pair (a,b) (x,y) = object [a .= x, b .= y]
 
 -- |Construct a 3-element JSON 'object' from a triple of keys and a triple of
 -- values.
 triple :: (ToJSON a, ToJSON b, ToJSON c) =>
-          (Text,Text,Text) -> (a,b,c) -> Value
+          (Key,Key,Key) -> (a,b,c) -> Value
 triple (a,b,c) (x,y,z) = object [a .= x, b.= y, c .= z]
 
 
@@ -100,12 +99,12 @@ fromJSON' :: MonadBaseControl IO wd => FromJSON a => Value -> wd a
 fromJSON' = aesonResultToWD . fromJSON
 
 -- |This operator is a wrapper over Aeson's '.:' operator.
-(!:) :: (MonadBaseControl IO wd, FromJSON a) => Object -> Text -> wd a
+(!:) :: (MonadBaseControl IO wd, FromJSON a) => Object -> Key -> wd a
 o !: k = aesonResultToWD $ parse (.: k) o
 
 -- |Due to a breaking change in the '.:?' operator of aeson 0.10 (see <https://github.com/bos/aeson/issues/287>) that was subsequently reverted, this operator
 -- was added to provide consistent behavior compatible with all aeson versions. If the field is either missing or `Null`, this operator should return a `Nothing` result.
-(.:??) :: FromJSON a => Object -> Text -> Parser (Maybe a)
+(.:??) :: FromJSON a => Object -> Key -> Parser (Maybe a)
 o .:?? k = fmap join (o .:? k)
 
 

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -44,7 +44,7 @@ Library
   if flag(developer)
     cpp-options: -DCABAL_BUILD_DEVELOPER
   build-depends:   base == 4.*
-                 , aeson >= 0.6.2.0
+                 , aeson >= 2.0
                  , http-client >= 0.3
                  , http-types >= 0.8
                  , text >= 0.11.3


### PR DESCRIPTION
See unofficial migration guide at https://github.com/haskell/aeson/issues/881#issuecomment-944920664.

It's possible that what we actually want to do is continue to support Aeson 1.6 via CPP. I haven't bothered with that here.