### PR TITLE
file api actually returns the remote file path

### DIFF
--- a/src/Test/WebDriver/Commands.hs
+++ b/src/Test/WebDriver/Commands.hs
@@ -663,24 +663,27 @@ setLocation = noReturn . doSessCommand methodPost "/location"
                         "altitude")
 
 -- |Uploads a file from the local filesystem by its file path.
-uploadFile :: (HasCallStack, WebDriver wd) => FilePath -> wd ()
+-- Returns the remote filepath of the file
+uploadFile :: (HasCallStack, WebDriver wd) => FilePath -> wd Text
 uploadFile path = uploadZipEntry =<< liftBase (readEntry [] path)
 
 -- |Uploads a raw bytestring with associated file info.
+-- Returns the remote filepath of the file
 uploadRawFile :: (HasCallStack, WebDriver wd) =>
                  FilePath          -- ^File path to use with this bytestring.
                  -> Integer        -- ^Modification time
                                    -- (in seconds since Unix epoch).
                  -> LBS.ByteString -- ^ The file contents as a lazy ByteString
-                 -> wd ()
+                 -> wd Text
 uploadRawFile path t str = uploadZipEntry (toEntry path t str)
 
 
 -- |Lowest level interface to the file uploading mechanism.
 -- This allows you to specify the exact details of
 -- the zip entry sent across network.
-uploadZipEntry :: (HasCallStack, WebDriver wd) => Entry -> wd ()
-uploadZipEntry = noReturn . doSessCommand methodPost "/file" . single "file"
+-- Returns the remote filepath of the extracted file
+uploadZipEntry :: (HasCallStack, WebDriver wd) => Entry -> wd Text
+uploadZipEntry = doSessCommand methodPost "/file" . single "file"
                  . TL.decodeUtf8 . B64.encode . fromArchive . (`addEntryToArchive` emptyArchive)
 
 


### PR DESCRIPTION
Hey I'm trying to iron out the differences between our fork and the main version so that any w3c related changes I do could possibly become a clean PR, and we can keep up with your improvements.

Here's the first one, the `/file` api is not well documented and seems to be a chrome only function but it does in fact return the remote file path so it can then be used as part of a test. Without knowing the remote file path you cannot do file tests like this on a remote server.

this docs page was the only one i could find that documented this behaviour
https://webdriver.io/docs/api/browser/uploadFile/