### PR TITLE
Make driverConfigLogDir optional

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Main where
 
@@ -8,9 +11,11 @@ import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift
 import Control.Monad.Logger
 import Control.Monad.Reader
+import qualified Data.Aeson as A
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
 import Data.String.Interpolate
+import qualified Data.Text as T
 import qualified Network.HTTP.Client as HC
 import Network.HTTP.Types.Status as N
 import Test.WebDriver
@@ -20,6 +25,18 @@ import UnliftIO.Concurrent (threadDelay)
 import UnliftIO.Directory
 import UnliftIO.Exception
 
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key as A
+import qualified Data.Aeson.KeyMap as KM
+
+aesonLookup :: T.Text -> KM.KeyMap v -> Maybe v
+aesonLookup = KM.lookup . A.fromText
+#else
+import qualified Data.HashMap.Strict as HM
+
+aesonLookup :: (Eq k, Hashable k) => k -> HM.HashMap k v -> Maybe v
+aesonLookup = HM.lookup
+#endif
 
 newtype WD a = WD (ReaderT Session (LoggingT IO) a)
   deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadCatch, MonadMask, MonadUnliftIO, MonadReader Session, MonadLogger)
@@ -29,7 +46,15 @@ doCommandBaseWithLogging driver method path args = do
   logDebugN [i|--> #{HC.method req} #{HC.path req}#{HC.queryString req} (#{showRequestBody (HC.requestBody req)})|]
   response <- tryAny (liftIO $ HC.httpLbs req (_driverManager driver)) >>= either throwIO return
   let (N.Status code _) = HC.responseStatus response
-  logDebugN [i|<-- #{code} #{response}|]
+
+  if | code >= 200 && code < 300 -> case A.eitherDecode (HC.responseBody response) of
+         -- For successful responses, try to pull out the "value" and show it
+         Right (A.Object (aesonLookup "value" -> Just value)) -> logDebugN [i|<-- #{code} #{A.encode value}|]
+         _ -> logDebugN [i|<-- #{code} #{HC.responseBody response}|]
+     -- For non-successful responses, log the entire response.
+     -- Reading the WebDriver spec, it would probably be sufficient to just show the "value" as above,
+     -- plus the HTTP status message.
+     | otherwise -> logDebugN [i|<-- #{code} #{response}|]
   return response
 
   where

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,6 @@ import qualified Data.ByteString.Lazy as BL
 import Data.String.Interpolate
 import qualified Network.HTTP.Client as HC
 import Network.HTTP.Types.Status as N
-import System.IO.Temp
 import Test.WebDriver
 import Test.WebDriver.Capabilities
 import Test.WebDriver.Types
@@ -72,13 +71,11 @@ main = do
             }
         }
 
-  tmpDir <- getCanonicalTemporaryDirectory >>= flip createTempDirectory "chromedriver-logs"
-
   let driverConfig = DriverConfigChromedriver {
         driverConfigChromedriver = chromedriverBin
         , driverConfigChromedriverFlags = []
         , driverConfigChrome = chromeBin
-        , driverConfigLogDir = tmpDir
+        , driverConfigLogDir = Nothing
         }
 
   runStdoutLoggingT $ bracket mkEmptyWebDriverContext teardownWebDriverContext $ \wdc -> do

--- a/package.yaml
+++ b/package.yaml
@@ -99,6 +99,7 @@ executables:
     - -O2
     - -W
     dependencies:
+    - aeson
     - base
     - bytestring
     - exceptions
@@ -107,6 +108,7 @@ executables:
     - monad-logger
     - mtl
     - string-interpolate
+    - text
     - unliftio
     - unliftio-core
     - webdriver

--- a/package.yaml
+++ b/package.yaml
@@ -107,7 +107,6 @@ executables:
     - monad-logger
     - mtl
     - string-interpolate
-    - temporary
     - unliftio
     - unliftio-core
     - webdriver

--- a/src/Test/WebDriver.hs
+++ b/src/Test/WebDriver.hs
@@ -197,7 +197,7 @@ mkManualDriver hostname port basePath requestHeaders = do
     , _driverManager = manager
     , _driverProcess = Nothing
     , _driverLogAsync = Nothing
-    , _driverConfig = DriverConfigChromedriver "" [] "" "" -- Not used
+    , _driverConfig = DriverConfigChromedriver "" [] "" Nothing -- Not used
     }
 
 -- | Tear down all sessions and processes associated with a 'WebDriverContext'.

--- a/src/Test/WebDriver.hs
+++ b/src/Test/WebDriver.hs
@@ -172,8 +172,9 @@ closeSession wdc sess@(Session {..}) = do
 -- not shut driver processes.
 closeSession' :: (WebDriverBase m, MonadLogger m) => Session -> m ()
 closeSession' (Session { sessionId=(SessionId sessId), .. }) = do
-  response <- doCommandBase sessionDriver methodDelete ("/session/" <> sessId) Null
-  logInfoN [i|Close result: #{response}|]
+  _response <- doCommandBase sessionDriver methodDelete ("/session/" <> sessId) Null
+  -- TODO: throw an exception if this failed?
+  return ()
 
 -- | Create a manual 'Driver' to use with 'startSession''/'closeSession''.
 mkManualDriver :: MonadIO m =>

--- a/src/Test/WebDriver/Types.hs
+++ b/src/Test/WebDriver/Types.hs
@@ -105,7 +105,7 @@ data DriverConfig =
     -- | Drivers to configure Selenium to use.
     , driverConfigSubDrivers :: [DriverConfig]
     -- | Directory in which to place driver logs.
-    , driverConfigLogDir :: FilePath
+    , driverConfigLogDir :: Maybe FilePath
     }
   | DriverConfigGeckodriver {
       -- | Path to @geckodriver@ binary.
@@ -115,7 +115,7 @@ data DriverConfig =
       -- | Path to @firefox@ binary.
       , driverConfigFirefox :: FilePath
       -- | Directory in which to place driver logs.
-      , driverConfigLogDir :: FilePath
+      , driverConfigLogDir :: Maybe FilePath
       }
   | DriverConfigChromedriver {
       -- | Path to @chromedriver@ binary.
@@ -125,7 +125,7 @@ data DriverConfig =
       -- | Path to @chrome@ binary.
       , driverConfigChrome :: FilePath
       -- | Directory in which to place driver logs.
-      , driverConfigLogDir :: FilePath
+      , driverConfigLogDir :: Maybe FilePath
       }
 
 -- | An opaque identifier for a WebDriver session. These handles are produced by

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -45,7 +45,7 @@ main = do
               driverConfigJava = java
               , driverConfigSeleniumJar = seleniumJar
               , driverConfigSubDrivers = subDrivers
-              , driverConfigLogDir = dir
+              , driverConfigLogDir = Just dir
               , driverConfigJavaFlags = []
               , driverConfigSeleniumVersion = Just Selenium3
               }
@@ -62,7 +62,7 @@ main = do
               driverConfigJava = java
               , driverConfigSeleniumJar = seleniumJar
               , driverConfigSubDrivers = subDrivers
-              , driverConfigLogDir = dir
+              , driverConfigLogDir = Just dir
               , driverConfigJavaFlags = []
               , driverConfigSeleniumVersion = Just Selenium4
               }
@@ -77,7 +77,7 @@ main = do
             return $ DriverConfigChromedriver {
               driverConfigChromedriver = chromedriver
               , driverConfigChrome = chrome
-              , driverConfigLogDir = dir
+              , driverConfigLogDir = Just dir
               , driverConfigChromedriverFlags = []
               }
 
@@ -91,7 +91,7 @@ main = do
             return $ DriverConfigGeckodriver {
               driverConfigGeckodriver = geckodriver
               , driverConfigFirefox = firefox
-              , driverConfigLogDir = dir
+              , driverConfigLogDir = Just dir
               , driverConfigGeckodriverFlags = []
               }
 
@@ -134,14 +134,14 @@ getSubDrivers dir = getContext browserDependencies >>= \case
     DriverConfigChromedriver {
         driverConfigChromedriver = browserDependenciesChromeChromedriver
         , driverConfigChrome = browserDependenciesChromeChrome
-        , driverConfigLogDir = dir
+        , driverConfigLogDir = Just dir
         , driverConfigChromedriverFlags = []
         }]
   BrowserDependenciesFirefox {..} -> return [
     DriverConfigGeckodriver {
         driverConfigGeckodriver = browserDependenciesFirefoxGeckodriver
         , driverConfigFirefox = browserDependenciesFirefoxFirefox
-        , driverConfigLogDir = dir
+        , driverConfigLogDir = Just dir
         , driverConfigGeckodriverFlags = []
     }]
 

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -156,7 +156,6 @@ executable demo
     , monad-logger
     , mtl
     , string-interpolate
-    , temporary
     , unliftio
     , unliftio-core
     , webdriver

--- a/webdriver.cabal
+++ b/webdriver.cabal
@@ -148,7 +148,8 @@ executable demo
       ScopedTypeVariables
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -O2 -W
   build-depends:
-      base
+      aeson
+    , base
     , bytestring
     , exceptions
     , http-client
@@ -156,6 +157,7 @@ executable demo
     , monad-logger
     , mtl
     , string-interpolate
+    , text
     , unliftio
     , unliftio-core
     , webdriver


### PR DESCRIPTION
Making it required was probably not a good idea, because it forces users to provide a temporary directory.