### PR TITLE
teardown: gracefully stop driver processes by signalling their group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 * Reduce BiDi log noise
+* Gracefully stop driver processes by signalling their whole process group (escalating sigINT -> sigTERM and waiting for exit), so the driver's browser child isn't left orphaned.
+* Bound each session close in `teardownWebDriverContext` with a timeout so an unresponsive driver can't block session teardown.
 
 ## 0.15.0.0
 * Add `Test.WebDriver.Commands.BiDi.NetworkActivity` with tools for working with browser network activity.

--- a/src/Test/WebDriver.hs
+++ b/src/Test/WebDriver.hs
@@ -95,6 +95,7 @@ import Network.HTTP.Types (RequestHeaders, statusCode)
 import UnliftIO.Concurrent
 import UnliftIO.Exception
 import UnliftIO.STM
+import UnliftIO.Timeout
 
 
 -- | Start a WebDriver session, with a given 'WebDriverContext' and
@@ -211,19 +212,26 @@ mkManualDriver hostname port basePath requestHeaders = do
     , _driverConfig = DriverConfigChromedriver "" [] Nothing "" Nothing -- Not used
     }
 
+-- | How long to wait for a single session's DELETE during context teardown before giving up.
+sessionCloseTimeoutUs :: Int
+sessionCloseTimeoutUs = 30 * 1000000 -- 30s
+
 -- | Tear down all sessions and processes associated with a 'WebDriverContext'.
 teardownWebDriverContext :: (WebDriverBase m, MonadLogger m) => WebDriverContext -> m ()
 teardownWebDriverContext (WebDriverContext {..}) = do
-  -- Atomically take all sessions and clear the map, so we can clean up each
-  -- one without holding the MVar (and without modifyMVar_ restoring the old
-  -- value if any individual cleanup throws).
+  -- Atomically take all sessions and clear the map, so we can clean up each one without holding the
+  -- MVar (and without modifyMVar_ restoring the old value if any individual cleanup throws).
   sessions <- modifyMVar _webDriverSessions $ \s -> return (mempty, M.toList s)
 
   forM_ sessions $ \(_name, sess) -> do
-    catch (closeSession' sess)
-          (\(e :: SomeException) -> logWarnN [i|Exception closing session during teardown: #{e}|])
-    -- Geckodriver runs one process per session; tear it down here since
-    -- closeSession' only sends the HTTP DELETE and doesn't manage processes.
+    -- Bound the close so an unresponsive driver can't stall teardown; the http-client response timeout
+    -- doesn't cover every stuck state (e.g. a hung connect).
+    tryAny (timeout sessionCloseTimeoutUs (closeSession' sess)) >>= \case
+      Right (Just ()) -> return ()
+      Right Nothing -> logWarnN [i|Timed out closing session during teardown|]
+      Left e -> logWarnN [i|Exception closing session during teardown: #{e}|]
+    -- Geckodriver runs one process per session; tear it down here since closeSession' only sends the
+    -- HTTP DELETE and doesn't manage processes.
     case _driverConfig (sessionDriver sess) of
       DriverConfigGeckodriver {} ->
         catch (teardownDriver (sessionDriver sess))

--- a/src/Test/WebDriver/LaunchDriver.hs
+++ b/src/Test/WebDriver/LaunchDriver.hs
@@ -245,13 +245,38 @@ mkDriverRequest (Driver {..}) meth wdPath args =
       ]
 
 
+-- | Grace period to wait at each escalation step when stopping a driver process.
+driverStopGracePeriodUs :: Int
+driverStopGracePeriodUs = 15_000_000
+
+gracefullyStopDriverProcess :: (MonadUnliftIO m, MonadLogger m) => ProcessHandle -> m ()
+gracefullyStopDriverProcess p = do
+  let waitForExit = do
+        let policy = limitRetriesByCumulativeDelay driverStopGracePeriodUs $ capDelay 200_000 $ exponentialBackoff 1_000
+        retrying policy (\_ x -> return (isNothing x)) $ \_ -> getProcessExitCode p
+
+  -- Interrupting can throw if the group is already gone (a benign race); anything else is worth surfacing.
+  let interruptGroup = tryAny (interruptProcessGroupOf p) >>= \case
+        Right () -> return ()
+        Left e -> logWarnN [i|Failed to interrupt driver process group: #{e}|]
+
+  interruptGroup
+  waitForExit >>= \case
+    Just _ -> return ()
+    Nothing -> do
+      logWarnN [i|Driver process didn't stop after interrupting its group; interrupting again|]
+      interruptGroup
+      waitForExit >>= \case
+        Just _ -> return ()
+        Nothing -> do
+          logWarnN [i|Driver process still didn't stop; terminating the leader|]
+          terminateProcess p
+          void waitForExit
+
 teardownDriver :: (MonadUnliftIO m, MonadLogger m) => Driver -> m ()
 teardownDriver (Driver {..}) = do
   case _driverProcess of
-    Just p -> do
-      terminateProcess p
-      -- Reap the child process to avoid leaving zombies.
-      void $ liftIO $ waitForProcess p
+    Just p -> gracefullyStopDriverProcess p
     Nothing -> return ()
   case _driverLogAsync of
     Just x -> cancel x


### PR DESCRIPTION
* and bound each session DELETE with a timeout